### PR TITLE
Scope max-height to monitoring dashboard dropdowns

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -238,8 +238,6 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
   border-width: 0 !important; // TEMP fix until https://github.com/patternfly/patternfly-next/issues/2019 is fixed upstream
   list-style: none;
   -webkit-overflow-scrolling: touch;
-  max-height: 60vh;
-  overflow-y: auto;
   @media (min-width: $pf-global--breakpoint--md) {
     &.pf-m-align-right-on-md {
       right: 0;

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -205,6 +205,11 @@ $screen-phone-landscape-min-width: 567px;
   overflow-x: auto;
 }
 
+.monitoring-dashboards__variable-dropdown .pf-c-dropdown__menu {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
 .monitoring-dashboards__variables {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -100,6 +100,7 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({
               {items[selectedKey]}
             </DropdownToggle>
           }
+          className="monitoring-dashboards__variable-dropdown"
         />
       )}
     </div>


### PR DESCRIPTION
@yapei, this is one way to scope the dropdown height fix to just the monitoring dashboard dropdowns.  Unfortunately, PatternFly does not allow us to add a class to the dropdown menu directly, so [a descendant selector](https://github.com/yapei/console/compare/master...rhamilto:1904305#diff-ef5d7e7b3a06779f91c59f6dd1667f144917ac325eab50a18bf2bff97a040847R208) is necessary.